### PR TITLE
Fix CMDW-83, CMDW-86, CMDW-88

### DIFF
--- a/export.js
+++ b/export.js
@@ -90,6 +90,11 @@ function exportToPath(compiledSHR, outPath) {
   compiledSHR.generateHTML();
 }
 
+function cleanConstraints(constraints) {
+  const firstWordRegex = /^\w+ constrained/;
+  return constraints.replace(firstWordRegex, 'Constrained');
+}
+
 function makeHtml(md) {
   // First we need to escape < and >
   if (md != null) {
@@ -197,7 +202,7 @@ function hasMoreThan0Fields(element) {
 // Function to generate and write html from an ejs template
 function renderEjsFile(template, pkg, outDirectory, filePath) {
   const destination = path.join(outDirectory, filePath);
-  ejs.renderFile(path.join(__dirname, template), Object.assign(pkg, { makeHtml: makeHtml, makeSummaryHtml: makeSummaryHtml, attachment: filePath, titleize: titleize, fieldSort: fieldSort, hasMoreThan0Fields: hasMoreThan0Fields, drupalVars: { exportTime: exportTime, exportVersion: exportVersion, idFor: idFor } }), (error, htmlText) => {
+  ejs.renderFile(path.join(__dirname, template), Object.assign(pkg, { makeHtml: makeHtml, makeSummaryHtml: makeSummaryHtml, attachment: filePath, titleize: titleize, fieldSort: fieldSort, hasMoreThan0Fields: hasMoreThan0Fields, cleanConstraints: cleanConstraints, drupalVars: { exportTime: exportTime, exportVersion: exportVersion, idFor: idFor } }), (error, htmlText) => {
     if (error) logger.error('Error rendering model doc: %s', error);
     else fs.writeFileSync(destination, htmlText);
   });

--- a/templates/dataElement.ejs
+++ b/templates/dataElement.ejs
@@ -67,9 +67,9 @@
                hierarchy.forEach(function(ancestor, i) { -%>
                 <% if (i == hierarchy.length - 2 && ancestor.path != "shr-base" && ancestor.name != 'CmsEcqmComposition') { -%>
                   <% if (ancestor.path == "qdm-dataelement" ) { %> 
-                  <dt>QDM Datatype:
+                  <dt>QDM Datatype - 
                   <% } else { %>
-                  <dt>Based On:
+                  <dt>QDM Attribute:
                   <% } %>
                     <a href="../<%= ancestor.path %>/<%= ancestor.name %>.html"><%= titleize(ancestor.name) %></a>
                   </dt>
@@ -85,7 +85,7 @@
           <ul class="class_list">
             <% element.children.forEach(function(child, i) { -%>
               <li>
-                <a href="../<%= child.path %>/<%= child.name %>.html"><%= titleize(child.name) -%></a><% if (i < (element.children.length - 1)){ %>&nbsp;<% } -%>
+                <a href="../<%= child.path %>/<%= child.name %>.html"><%= titleize(child.name) -%></a><% if (i < (element.children.length - 1)) { %>&nbsp;<% } -%>
               </li>
             <% }) -%>
           </ul>

--- a/templates/tables/dataElementDescription.ejs
+++ b/templates/tables/dataElementDescription.ejs
@@ -13,6 +13,6 @@ if (cf_raw != undefined) {
     <label>Exclusion Criteria:</label> <%- ec && ec.trim() != '' ? ec + "<br>" : '<span class="na">n/a</span>' %>
   <% var constraints = description.split("-- ")[1];
     if (constraints && constraints.trim() != '') { -%>
-      <%- makeHtml(constraints.trim()) -%>
+      <%- makeHtml(cleanConstraints(constraints.trim())) -%>
     <% } %>
 <% } %>

--- a/templates/tables/fieldRow.ejs
+++ b/templates/tables/fieldRow.ejs
@@ -11,7 +11,7 @@
     <% if (field.path == 'ecqm-dataelement') { %>
       <div><%- include('./dataElementDescription', { description: field.description }) -%></div>
       <% basedOn = dataElements[dataElements[field.fqn].basedOn[0]] %>
-      <div><b><%= titleize(basedOn.name) %>:</b> <%= basedOn.description %></div>
+      <div><b>QDM Datatype - <%= titleize(basedOn.name) %>:</b> <%= basedOn.description %></div>
     <% } else { %>
       <div><%- makeHtml(field.description) %></div>
     <% } %>


### PR DESCRIPTION
CMDW-83: [Add wording before the QDM Datatype to make it clear it is a QDM Datatype Definition](https://oncprojectracking.healthit.gov/support/browse/CMDW-83)
Fixed by adding `QDM Datatype - ` before the name of the datatype.

CMDW-86: [In Value Set Description make sure that Result Value is used consistently](https://oncprojectracking.healthit.gov/support/browse/CMDW-86)
Fixed by getting rid of "Result Value" and other SHR-ish phrases entirely (see `cleanConstraints` in `export.js`)

CMDW-88: [Replace "Based on" with something else](https://oncprojectracking.healthit.gov/support/browse/CMDW-88)
Fixed by changing "Based on" to "QDM Attribute".